### PR TITLE
Latest httpd and perl

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -44,7 +44,7 @@ HAS_EXTUTILS_EMBED=`$PERL -MExtUtils::Embed -e 'print "yes"'`
 if test "$HAS_EXTUTILS_EMBED" != "yes"; then
     AC_MSG_ERROR([ExtUtils::Embed not found. Please install it.])
 fi
-PERL_CCOPTS=`$PERL -MExtUtils::Embed -e ccopts | sed -e 's/-D_FILE_OFFSET_BITS=64//'`
+PERL_CCOPTS=`$PERL -MExtUtils::Embed -e ccopts`
 PERL_LDOPTS=`$PERL -MExtUtils::Embed -e ldopts`
 AC_SUBST(PERL_CCOPTS)
 AC_SUBST(PERL_LDOPTS)

--- a/t/00_output.t
+++ b/t/00_output.t
@@ -1,5 +1,6 @@
 use strict;
 use warnings;
+use lib '.';
 use t::TestModPSGI;
 
 BEGIN {

--- a/t/01_lint.t
+++ b/t/01_lint.t
@@ -1,5 +1,6 @@
 use strict;
 use warnings;
+use lib '.';
 use t::TestModPSGI;
 
 return eval_body_app if running_in_mod_psgi;

--- a/t/02_input.t
+++ b/t/02_input.t
@@ -44,7 +44,7 @@ content: f
 method: POST
 code: |
   $env->{'psgi.input'}->read(my $buf, $env->{CONTENT_LENGTH});
-  $buf;
+  join('&', sort split('&', $buf))
 args:
   - a: 1
     b: 2

--- a/t/02_input.t
+++ b/t/02_input.t
@@ -1,5 +1,6 @@
 use strict;
 use warnings;
+use lib '.';
 use t::TestModPSGI;
 
 return eval_body_app if running_in_mod_psgi;

--- a/t/03_errors.t
+++ b/t/03_errors.t
@@ -1,5 +1,6 @@
 use strict;
 use warnings;
+use lib '.';
 use t::TestModPSGI;
 
 return eval_body_app if running_in_mod_psgi;

--- a/t/04_die.t
+++ b/t/04_die.t
@@ -1,5 +1,6 @@
 use strict;
 use warnings;
+use lib '.';
 use t::TestModPSGI;
 
 return eval_body_app if running_in_mod_psgi;

--- a/t/TestModPSGI.pm
+++ b/t/TestModPSGI.pm
@@ -112,8 +112,11 @@ sub run_httpd($) {
     my $conf = <<"END_CONF";
 ServerName mod-psgi.test
 LoadModule psgi_module $topdir/.libs/mod_psgi.so
+LoadModule mpm_event_module modules/mod_mpm_event.so
+LoadModule unixd_module modules/mod_unixd.so
+LoadModule authn_core_module modules/mod_authn_core.so
+LoadModule authz_core_module modules/mod_authz_core.so
 PidFile  $tmpdir/httpd.pid
-LockFile $tmpdir/httpd.lock
 ErrorLog $tmpdir/error_log
 Listen $port
 <Location />

--- a/t/suite.t
+++ b/t/suite.t
@@ -2,6 +2,7 @@ use strict;
 use warnings;
 use Test::More;
 use Plack::Test::Suite;
+use lib '.';
 require t::TestModPSGI;
 
 BEGIN {


### PR DESCRIPTION
I tried to build and run tests with httpd 2.4.37 and perl 5.28.0 and discovered some issues. This patch set fixes all the issues.

It reverts the "Removed -D_FILE_OFFSET_BITS=64" commit because RHEL-5 end-of-life and unsupported now.

It changes tests to work work with httpd 2.4. They will break on older httpd 2.2 probably. If you are insterested, I can try to make them working on both httpd.