### PR TITLE
Updates to build rpm from tar ball (CentOS 7)

### DIFF
--- a/01-psgi.conf
+++ b/01-psgi.conf
@@ -1,0 +1,1 @@
+LoadModule psgi_module modules/mod_psgi.so

--- a/Makefile.in
+++ b/Makefile.in
@@ -51,12 +51,12 @@ stop:
 
 DIST_DIR=$(PACKAGE_NAME)-$(PACKAGE_VERSION)
 DIST_FILE=$(PACKAGE_NAME)-$(PACKAGE_VERSION).tar
-dist: ppport.h configure
+dist:	ppport.h configure 01-psgi.conf mod_psgi.spec
 	rm -f $(DIST_FILE)
 	git archive --format=tar --prefix=$(DIST_DIR)/ HEAD > $(DIST_FILE)
 	mkdir $(DIST_DIR)
-	cp ppport.h configure $(DIST_DIR)
-	tar rf $(DIST_FILE) $(DIST_DIR)/ppport.h $(DIST_DIR)/configure
+	cp ppport.h configure 01-psgi.conf mod_psgi.spec $(DIST_DIR)
+	tar rf $(DIST_FILE) $(DIST_DIR)/ppport.h $(DIST_DIR)/configure $(DIST_DIR)/01-psgi.conf $(DIST_DIR)/mod_psgi.spec
 	rm -fr $(DIST_DIR)
 	gzip --best $(DIST_FILE)
 

--- a/mod_psgi.spec
+++ b/mod_psgi.spec
@@ -1,6 +1,6 @@
 Name:		mod_psgi
-Version:	0.0.0
-Release:	1%{?dist}
+Version:	0.0.1
+Release:	2%{?dist}
 Summary:	Perl PSGI modules for the Apache HTTP Server
 
 Group:		System Environment/Daemons
@@ -25,6 +25,11 @@ make %{?_smp_mflags}
 
 %install
 make install DESTDIR=%{buildroot}
+mkdir -p %{buildroot}/%{_sysconfdir}/httpd/conf.modules.d/
+cp 01-psgi.conf %{buildroot}/%{_sysconfdir}/httpd/conf.modules.d/
+
+%post
+service httpd reload
 
 %files
 %defattr(-,root,root)

--- a/mod_psgi.spec
+++ b/mod_psgi.spec
@@ -1,0 +1,34 @@
+Name:		mod_psgi
+Version:	0.0.0
+Release:	1%{?dist}
+Summary:	Perl PSGI modules for the Apache HTTP Server
+
+Group:		System Environment/Daemons
+License:	Apache License 2.0
+URL:		https://github.com/spiritloose/mod_psgi
+Source0:	https://github.com/spiritloose/mod_psgi/mod_psgi-0.0.1.tar.gz
+
+BuildRequires:	httpd-devel >= 2.4
+BuildRequires:	httpd-devel >= 2.4
+Requires:	httpd >= 2.4
+
+%description
+The mod_psgi module adds support for Perl PSGI to the Apache HTTP Server.
+
+%prep
+%setup -q
+
+%build
+autoconf
+%configure
+make %{?_smp_mflags}
+
+%install
+make install DESTDIR=%{buildroot}
+
+%files
+%defattr(-,root,root)
+%{_libdir}/httpd/modules/mod_psgi.so
+%config(noreplace) %{_sysconfdir}/httpd/conf.modules.d/01-psgi.conf
+
+%changelog


### PR DESCRIPTION
To build RPM
```
autoconf
./configure
make dist
rpmbuild -ta mod_psgi-*.tar.gz
```